### PR TITLE
Awards video links, alums corrections

### DIFF
--- a/alums/community/aavc/awards-program/index.php
+++ b/alums/community/aavc/awards-program/index.php
@@ -91,15 +91,14 @@ $page_info = json_decode($page_info, true);
 <h6 class="tagline">2022 Recipient</h6>
 <h1>Deborah Macfarlan Enright ’82</h1>
 
-<!--
+
 <p><?php echo item_link_VideoModal(
     'Watch the video',
-    'https://player.vimeo.com/video/574099032',
+    'https://player.vimeo.com/video/788023992',
     'vimeo',
     '',
     'no-arrow btn-link mt-4'
 ); ?></p>
--->
 
 <?php echo cta_link(
     'https://www.vassar.edu/news/five-alumni-selected-2022-aavc-awards',
@@ -177,15 +176,13 @@ $page_info = json_decode($page_info, true);
 <h1>Edward Pittman ’82</h1>
 <p class="intro-text">Senior Associate Dean of the College (Retired)</p>
 
-<!--
 <p><?php echo item_link_VideoModal(
     'Watch the video',
-    'https://player.vimeo.com/video/637580661',
+    'https://player.vimeo.com/video/788004126',
     'vimeo',
     '',
     'no-arrow btn-link mt-4'
 ); ?></p>
--->
 
 <?php echo cta_link(
     'https://www.vassar.edu/news/five-alumni-selected-2022-aavc-awards',

--- a/alums/community/aavc/awards-program/outstanding-faculty-staff/index.php
+++ b/alums/community/aavc/awards-program/outstanding-faculty-staff/index.php
@@ -42,16 +42,15 @@ $page_info = json_decode($page_info, true);
 <h4>Edward Pittman ’82, Senior Associate Dean of the College (Retired)</h4>
 
 <ul class="linked-list">
-  <!--
   <li>
     <?php echo item_link_VideoModal(
         'Watch the video',
-        'https://player.vimeo.com/video/637580661?h=2fa683eea6',
+        'https://player.vimeo.com/video/788004126',
         'vimeo',
         '',
         'no-arrow'
     ); ?>
-  </li>-->
+  </li>
 
 	<li><a href="https://www.vassar.edu/news/five-alumni-selected-2022-aavc-awards">Read about the recipient</a></li>
 </ul>

--- a/alums/community/aavc/awards-program/outstanding-service/index.php
+++ b/alums/community/aavc/awards-program/outstanding-service/index.php
@@ -44,15 +44,15 @@ $page_info = json_decode($page_info, true);
 
 
 <ul class="linked-list">
-<!--  <li>
+  <li>
     <?php echo item_link_VideoModal(
         'Watch the video',
-        'https://player.vimeo.com/video/574099032?h=59bf2d53a8',
+        'https://player.vimeo.com/video/788023992',
         'vimeo',
         '',
         'no-arrow'
     ); ?>
-  </li> -->
+  </li>
 		<li><a href="https://www.vassar.edu/news/five-alumni-selected-2022-aavc-awards">Read about the recipient</a></li>
 	</ul>
 

--- a/alums/give/volunteer/index.php
+++ b/alums/give/volunteer/index.php
@@ -96,7 +96,7 @@ $page_info = json_decode($page_info, true);
     'handshake',
     'icon-on-left theme-white-border'
 ); ?>
-<p>The Vassar College Alumni Admission Program (VCAAP) connects alums volunteers with various opportunities that support the work of Vassar’s Office of Admission. VCAAP volunteers help to increase the visibility of Vassar in their local communities and provide valuable points of contact for prospective students.</p>
+<p>The Vassar College Alumni Admission Program (VCAAP) connects alum volunteers with various opportunities that support the work of Vassar’s Office of Admission. VCAAP volunteers help to increase the visibility of Vassar in their local communities and provide valuable points of contact for prospective students.</p>
 <ul class="linked-list">
     <li><a href="https://apply.vassar.edu/portal/vcaap">Become a VCAAP Volunteer</a></li>
 </ul>
@@ -130,7 +130,7 @@ $page_info = json_decode($page_info, true);
     'users',
     'icon-on-left theme-white-border'
 ); ?>
-<p>Strengthen alums communities that center shared experiences, activities, and identities, such as athletic teams, singing groups, LGBTQ+, ALANA organizations, veterans, and First Gen alums (among others).</p>
+<p>Strengthen alum communities that center shared experiences, activities, and identities, such as athletic teams, singing groups, LGBTQ+, ALANA organizations, veterans, and First Gen alums (among others).</p>
 <ul class="linked-list">
     <li><a href="/alums/community/alum-groups/">Learn more about Affinity Groups</a></li>
    <!-- cyreview <li><a href="#">Become an Affinity Group Volunteer</a></li> -->


### PR DESCRIPTION
Added video links to Outstanding Service and Outstanding Faculty awards pages, corrected instances of "alums" to "alum" on Give>Volunteer landing page.